### PR TITLE
Quick fix for WPA showing as WEP

### DIFF
--- a/iw_parse.py
+++ b/iw_parse.py
@@ -84,9 +84,9 @@ def get_encryption(cell):
         for line in cell:
             matching = match(line,"IE:")
             if matching != None:
-                wpa = match(matching,"WPA Version ")
+                wpa = match(matching,"WPA")
                 if wpa != None:
-                    enc = "WPA v." + wpa
+                    enc = wpa
         if enc == "":
             enc = "WEP"
     return enc


### PR DESCRIPTION
Modified get_encryption() to match on "WPA" instead of "WPA Version ". This will allow it to pick up WPA and WPA2. The only loss is that it shows "WPA2 Version 1" instead of "WPA2 v.1"....basically it looses the abbreviation of version.